### PR TITLE
Fixed percent sign not escaped

### DIFF
--- a/GithubMarkdown.php
+++ b/GithubMarkdown.php
@@ -102,7 +102,7 @@ class GithubMarkdown extends Markdown
 	 */
 	protected function renderAutoUrl($block)
 	{
-		return '\url{' . $this->escapeUrl($block[1]) . '}';
+		return '\url{' . $this->escapeLatex($block[1]) . '}';
 	}
 
 	/**

--- a/Markdown.php
+++ b/Markdown.php
@@ -216,9 +216,9 @@ class Markdown extends \cebe\markdown\Parser
 			return '\hyperref['.str_replace('#', '::', $url).']{' . $text . '}';
 		} else {
 			if ($this->linkStyle === self::LINK_STYLE_HREF) {
-				return '\href{' . $this->escapeUrl($url) . '}{' . $text . '}';
+				return '\href{' . $this->escapeLatex($url) . '}{' . $text . '}';
 			}
-			return $text . '\\footnote{' . (empty($block['title']) ? '' : $this->escapeLatex($block['title']) . ': ') . '\url{' . $this->escapeUrl($url) . '}}';
+			return $text . '\\footnote{' . (empty($block['title']) ? '' : $this->escapeLatex($block['title']) . ': ') . '\url{' . $this->escapeLatex($url) . '}}';
 		}
 	}
 
@@ -278,7 +278,7 @@ class Markdown extends \cebe\markdown\Parser
 	 */
 	protected function renderEmail($block)
 	{
-		$email = $this->escapeUrl($block[1]);
+		$email = $this->escapeLatex($block[1]);
 		return "\\href{mailto:{$email}}{{$email}}";
 	}
 
@@ -287,7 +287,7 @@ class Markdown extends \cebe\markdown\Parser
 	 */
 	protected function renderUrl($block)
 	{
-		return '\url{' . $this->escapeUrl($block[1]) . '}';
+		return '\url{' . $this->escapeLatex($block[1]) . '}';
 	}
 
 	/**
@@ -345,14 +345,6 @@ class Markdown extends \cebe\markdown\Parser
 	private $_escaper;
 
 	/**
-	 * Escape special characters in URLs
-	 */
-	protected function escapeUrl($string)
-	{
-		return str_replace('%', '\\%', $this->escapeLatex($string));
-	}
-
-	/**
 	 * Escape special LaTeX characters
 	 */
 	protected function escapeLatex($string)
@@ -360,7 +352,8 @@ class Markdown extends \cebe\markdown\Parser
 		if ($this->_escaper === null) {
 			$this->_escaper = new TextToLatex();
 		}
-		return $this->_escaper->convert($string);
+		$output = $this->_escaper->convert($string);
+		return str_replace('%', '\\%', $output);
 	}
 
 	/**


### PR DESCRIPTION
Removed `Markdown::escapeUrl` as it wouldn't do anything...

Supersedes #13, fixes #11 